### PR TITLE
History Heuristic

### DIFF
--- a/src/engine/movegen.rs
+++ b/src/engine/movegen.rs
@@ -122,21 +122,21 @@ pub fn score_moves(
     }
 
     if mv.promotion.is_some() {
-        return 30_000;
+        return 31_000;
     }
 
-    // Returns between 1000..6000
+    // Returns between 5000..30000
     if piece_num_at(board, mv.to) != 0 {
-        return mvvlva(board, mv) * 10;
+        return mvvlva(board, mv) * 50;
     }
 
     if search.killers[ply as usize][0] == Some(mv) {
-        500
+        return 5000;
     } else if search.killers[ply as usize][1] == Some(mv) {
-        400
-    } else {
-        search.history[board.side_to_move() as usize][mv.to as usize][mv.from as usize] as i16
+        return 4500;
     }
+
+    search.history[board.side_to_move() as usize][mv.to as usize][mv.from as usize] as i16
 }
 
 pub fn pick_move(moves: &mut [MoveEntry], index: usize) -> Move {

--- a/src/engine/movegen.rs
+++ b/src/engine/movegen.rs
@@ -131,12 +131,12 @@ pub fn score_moves(
     }
 
     if search.killers[ply as usize][0] == Some(mv) {
-        return 500;
+        500
     } else if search.killers[ply as usize][1] == Some(mv) {
-        return 400;
+        400
+    } else {
+        search.history[board.side_to_move() as usize][mv.to as usize][mv.from as usize] as i16
     }
-
-    0
 }
 
 pub fn pick_move(moves: &mut [MoveEntry], index: usize) -> Move {

--- a/src/engine/search.rs
+++ b/src/engine/search.rs
@@ -17,6 +17,7 @@ pub struct Search {
     pub tt: TT,
     pub game_history: Vec<u64>,
     pub killers: [[Option<Move>; 2]; MAX_PLY as usize],
+    pub history: [[[u16; 64]; 64]; 2],
 }
 
 impl Search {
@@ -31,6 +32,7 @@ impl Search {
             tt,
             game_history: vec![],
             killers: [[None; 2]; MAX_PLY as usize],
+            history: [[[0; 64]; 64]; 2],
         }
     }
 
@@ -158,8 +160,12 @@ impl Search {
                 if score > alpha {
                     alpha = score;
                     best_move = Some(mv);
-
                     self.pv_table.store(ply, mv);
+
+                    if quiet_move(board, mv) {
+                        self.history[board.side_to_move() as usize][mv.to as usize]
+                            [mv.from as usize] += depth as u16;
+                    }
 
                     if score >= beta {
                         if quiet_move(board, mv) {

--- a/src/engine/search.rs
+++ b/src/engine/search.rs
@@ -162,15 +162,13 @@ impl Search {
                     best_move = Some(mv);
                     self.pv_table.store(ply, mv);
 
-                    if quiet_move(board, mv) {
-                        self.history[board.side_to_move() as usize][mv.to as usize]
-                            [mv.from as usize] += depth as u16;
-                    }
-
                     if score >= beta {
                         if quiet_move(board, mv) {
                             self.killers[ply as usize][1] = self.killers[ply as usize][0];
                             self.killers[ply as usize][0] = Some(mv);
+
+                            self.history[board.side_to_move() as usize][mv.to as usize]
+                                [mv.from as usize] += (depth * depth) as u16;
                         }
 
                         break;

--- a/src/uci.rs
+++ b/src/uci.rs
@@ -273,4 +273,5 @@ fn reset_search(search: &mut Search) {
     search.pv_table = crate::engine::pv_table::PVTable::new();
     search.nodes = 0;
     search.killers = [[None; 2]; MAX_PLY as usize];
+    search.history = [[[0; 64]; 64]; 2];
 }

--- a/src/uci.rs
+++ b/src/uci.rs
@@ -226,7 +226,7 @@ pub fn main_loop() {
 
 fn id() {
     println!("id name Svart {}", env!("CARGO_PKG_VERSION"));
-    println!("id author Crippa");
+    println!("id author crippa");
 }
 
 fn options() {


### PR DESCRIPTION
Score of svart-history vs svart-master: 804 - 634 - 445  [0.545] 1883
...      svart-history playing White: 431 - 293 - 217  [0.573] 941
...      svart-history playing Black: 373 - 341 - 228  [0.517] 942
...      White vs Black: 772 - 666 - 445  [0.528] 1883
Elo difference: 31.5 +/- 13.7, LOS: 100.0 %, DrawRatio: 23.6 %
SPRT: llr 2.96 (100.4%), lbound -2.94, ubound 2.94 - H1 was accepted