### PR TITLE
Null Move Pruning

### DIFF
--- a/src/engine/search.rs
+++ b/src/engine/search.rs
@@ -117,6 +117,23 @@ impl Search {
             }
         }
 
+        let in_check = !board.checkers().is_empty();
+
+        // Null move pruning
+        if depth >= 3 && !in_check {
+            let new_board = board.null_move().unwrap();
+
+            let mut score = -self.pvsearch(&new_board, -beta, -beta + 1, depth - 2, ply + 1, false);
+
+            if score >= beta {
+                if score >= TB_WIN_IN_PLY {
+                    score = beta;
+                }
+
+                return score;
+            }
+        }
+
         /////////////////
         // Search body //
         /////////////////
@@ -128,7 +145,7 @@ impl Search {
 
         // Checkmates and stalemates
         if move_list.is_empty() {
-            if !board.checkers().is_empty() {
+            if in_check {
                 return ply as i16 - MATE;
             } else {
                 return 0;


### PR DESCRIPTION
Score of svart-nmp vs svart-master: 161 - 79 - 70  [0.632] 310
...      svart-nmp playing White: 79 - 45 - 32  [0.609] 156
...      svart-nmp playing Black: 82 - 34 - 38  [0.656] 154
...      White vs Black: 113 - 127 - 70  [0.477] 310
Elo difference: 94.1 +/- 35.0, LOS: 100.0 %, DrawRatio: 22.6 %
SPRT: llr 2.95 (100.3%), lbound -2.94, ubound 2.94 - H1 was accepted