### PR TITLE
Fail-Hard NMP

### DIFF
--- a/engine/src/body/search.rs
+++ b/engine/src/body/search.rs
@@ -229,11 +229,7 @@ impl Search {
                     -self.zw_search(&new_b, &mut old_pv, -beta, -beta + 1, depth - r, ply + 1);
 
                 if score >= beta {
-                    if score >= TB_WIN_IN_PLY {
-                        return beta;
-                    }
-
-                    return score;
+                    return beta;
                 }
             }
         }


### PR DESCRIPTION
```
ELO   | 29.81 +- 12.10 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 1776 W: 571 L: 419 D: 786
```
https://chess.swehosting.se/test/1198/

Bench: 9274116