### PR TITLE
Node count TM

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -305,7 +305,7 @@ Internal Iterative Reduction (IIR)
     https://chess.swehosting.se/test/757/
 
 ====================================================================================
-Release 5 [May 31/June 6 2023]
+Release 5 [May 31/June 1 2023]
 
 Fail-Hard NMP
 
@@ -322,5 +322,22 @@ TT Move alpha
     LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
     GAMES | N: 1424 W: 463 L: 314 D: 647
     https://chess.swehosting.se/test/1203/
+
+====================================================================================
+5.1 [June 3]
+
+Node count TM
+
+    ELO   | 8.15 +- 5.55 (95%)
+    SPRT  | 8.0+0.08s Threads=1 Hash=16MB
+    LLR   | 3.03 (-2.94, 2.94) [0.00, 5.00]
+    GAMES | N: 8104 W: 2277 L: 2087 D: 3740
+    https://chess.swehosting.se/test/1278/
+
+    ELO   | 14.31 +- 7.76 (95%)
+    SPRT  | 40.0+0.40s Threads=1 Hash=256MB
+    LLR   | 2.99 (-2.94, 2.94) [0.00, 5.00]
+    GAMES | N: 3888 W: 1061 L: 901 D: 1926
+    https://chess.swehosting.se/test/1276/
 
 ====================================================================================

--- a/engine/src/body/search.rs
+++ b/engine/src/body/search.rs
@@ -581,7 +581,7 @@ impl Search {
                     [best_move.unwrap().to as usize] as f64
                     / self.info.nodes as f64;
 
-                let time_factor = (1.5 - best_move_fraction) * 2.04;
+                let time_factor = (1.5 - best_move_fraction) * 1.5;
                 opt = (self.info.base_optimum.unwrap() as f64 * time_factor) as u64;
                 
 

--- a/engine/src/body/search.rs
+++ b/engine/src/body/search.rs
@@ -581,7 +581,7 @@ impl Search {
                     [best_move.unwrap().to as usize] as f64
                     / self.info.nodes as f64;
 
-                let time_factor = 1.5 - best_move_fraction;
+                let time_factor = (1.5 - best_move_fraction) * 1.35;
                 opt = (self.info.base_optimum.unwrap() as f64 * time_factor) as u64;
                 
 

--- a/engine/src/body/search.rs
+++ b/engine/src/body/search.rs
@@ -581,7 +581,7 @@ impl Search {
                     [best_move.unwrap().to as usize] as f64
                     / self.info.nodes as f64;
 
-                let time_factor = (1.5 - best_move_fraction) * 1.75;
+                let time_factor = (1.5 - best_move_fraction) * 1.35;
                 opt = (self.info.base_optimum.unwrap() as f64 * time_factor) as u64;
                 
 

--- a/engine/src/body/search.rs
+++ b/engine/src/body/search.rs
@@ -581,7 +581,7 @@ impl Search {
                     [best_move.unwrap().to as usize] as f64
                     / self.info.nodes as f64;
 
-                let time_factor = (1.5 - best_move_fraction) * 1.5;
+                let time_factor = (1.5 - best_move_fraction) * 1.2;
                 opt = (self.info.base_optimum.unwrap() as f64 * time_factor) as u64;
                 
 

--- a/engine/src/body/search.rs
+++ b/engine/src/body/search.rs
@@ -581,7 +581,7 @@ impl Search {
                     [best_move.unwrap().to as usize] as f64
                     / self.info.nodes as f64;
 
-                let time_factor = (1.5 - best_move_fraction) * 1.2;
+                let time_factor = 1.5 - best_move_fraction;
                 opt = (self.info.base_optimum.unwrap() as f64 * time_factor) as u64;
                 
 

--- a/engine/src/body/search.rs
+++ b/engine/src/body/search.rs
@@ -38,8 +38,10 @@ pub struct SearchInfo {
     pub stop: bool,
     pub search_type: SearchType,
     pub timer: Option<Instant>,
+    pub base_optimum: Option<u64>,
     pub max_time: Option<u64>,
     pub nodes: u64,
+    pub node_table: [[u64; 64]; 64],
     pub seldepth: usize,
     pub game_history: Vec<u64>,
     pub killers: [[Option<Move>; 2]; MAX_PLY],
@@ -53,8 +55,10 @@ impl SearchInfo {
             stop: false,
             search_type: SearchType::Depth(0),
             timer: None,
+            base_optimum: None,
             max_time: None,
             nodes: 0,
+            node_table: [[0; 64]; 64],
             seldepth: 0,
             game_history: vec![],
             killers: [[None; 2]; MAX_PLY],
@@ -285,6 +289,7 @@ impl Search {
             moves_played += 1;
             self.info.game_history.push(board.hash());
             self.info.nodes += 1;
+            let previous_nodes = self.info.nodes;
             let gives_check = !board.checkers().is_empty();
 
             let mut score: i32;
@@ -343,6 +348,12 @@ impl Search {
 
             self.info.game_history.pop();
             self.nnue.pop();
+
+            if root {
+                // Difference in node count
+                self.info.node_table[mv.from as usize][mv.to as usize] +=
+                    self.info.nodes - previous_nodes;
+            }
 
             if score <= best_score {
                 continue;
@@ -503,6 +514,7 @@ impl Search {
                 depth = MAX_PLY;
                 self.info.timer = Some(Instant::now());
                 self.info.max_time = Some(max);
+                self.info.base_optimum = Some(opt);
                 opt_time = Some(opt);
             }
             SearchType::Infinite => {
@@ -559,8 +571,20 @@ impl Search {
                 }
             }
 
-            // Optimal time is up
-            if let Some(opt) = opt_time {
+            // Optimal time check
+            if let Some(mut opt) = opt_time {
+                // Time bound adjustments
+                #[rustfmt::skip]
+                let best_move_fraction = 
+                    self.info.node_table
+                    [best_move.unwrap().from as usize]
+                    [best_move.unwrap().to as usize] as f64
+                    / self.info.nodes as f64;
+
+                let time_factor = (1.5 - best_move_fraction) * 2.04;
+                opt = (self.info.base_optimum.unwrap() as f64 * time_factor) as u64;
+                
+
                 if info_timer.elapsed().as_millis() as u64 >= opt {
                     break;
                 }
@@ -646,7 +670,9 @@ impl Search {
         self.info.search_type = SearchType::Depth(0);
         self.info.timer = None;
         self.info.max_time = None;
+        self.info.base_optimum = None;
         self.info.nodes = 0;
+        self.info.node_table = [[0; 64]; 64];
         self.info.seldepth = 0;
         self.info.killers = [[None; 2]; MAX_PLY];
         self.info.history.age_table();

--- a/engine/src/body/search.rs
+++ b/engine/src/body/search.rs
@@ -581,7 +581,7 @@ impl Search {
                     [best_move.unwrap().to as usize] as f64
                     / self.info.nodes as f64;
 
-                let time_factor = (1.5 - best_move_fraction) * 1.35;
+                let time_factor = (1.5 - best_move_fraction) * 1.75;
                 opt = (self.info.base_optimum.unwrap() as f64 * time_factor) as u64;
                 
 

--- a/engine/src/ideas.txt
+++ b/engine/src/ideas.txt
@@ -1,2 +1,0 @@
-tuning RFP margin
-see

--- a/engine/src/uci/handler.rs
+++ b/engine/src/uci/handler.rs
@@ -13,7 +13,7 @@ pub enum SearchType {
 }
 
 fn id() {
-    println!("id name Svart 5");
+    println!("id name Svart 5.1");
     println!("id author Crippa");
 }
 


### PR DESCRIPTION
STC - https://chess.swehosting.se/test/1278/
```
ELO   | 8.15 +- 5.55 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.03 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 8104 W: 2277 L: 2087 D: 3740
```

LTC - https://chess.swehosting.se/test/1276/
```
ELO   | 14.31 +- 7.76 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=256MB
LLR   | 2.99 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 3888 W: 1061 L: 901 D: 1926
```