### PR TITLE
Use more of the increment time

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -341,3 +341,20 @@ Node count TM
     https://chess.swehosting.se/test/1276/
 
 ====================================================================================
+5.2 [June 10]
+
+Use more of the increment time
+
+    STC - https://chess.swehosting.se/test/1488/
+    ELO   | 9.41 +- 6.19 (95%)
+    SPRT  | 8.0+0.08s Threads=1 Hash=16MB
+    LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
+    GAMES | N: 6576 W: 1877 L: 1699 D: 3000
+
+    LTC - https://chess.swehosting.se/test/1490/
+    ELO   | 4.02 +- 3.22 (95%)
+    SPRT  | 40.0+0.40s Threads=1 Hash=256MB
+    LLR   | 2.98 (-2.94, 2.94) [0.00, 5.00]
+    GAMES | N: 22376 W: 5740 L: 5481 D: 11155
+
+====================================================================================

--- a/engine/src/uci/handler.rs
+++ b/engine/src/uci/handler.rs
@@ -13,7 +13,7 @@ pub enum SearchType {
 }
 
 fn id() {
-    println!("id name Svart 5.1");
+    println!("id name Svart 5.2");
     println!("id author Crippa");
 }
 

--- a/engine/src/uci/timeman.rs
+++ b/engine/src/uci/timeman.rs
@@ -17,7 +17,7 @@ pub fn time_for_move(time: u64, inc: u64, moves_to_go: Option<u8>) -> (u64, u64)
         max_time = (5. * opt_time).min(eight);
     // normal TC
     } else {
-        let temp = ((time / 20) + (inc / 2)) as f64;
+        let temp = ((time / 20) + (inc * 3 / 4)) as f64;
         opt_time = 0.6 * temp;
         max_time = (temp * 2.).min(time as f64);
     }


### PR DESCRIPTION
STC - https://chess.swehosting.se/test/1488/
```
ELO   | 9.41 +- 6.19 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 6576 W: 1877 L: 1699 D: 3000
```

LTC - https://chess.swehosting.se/test/1490/
```
ELO   | 4.02 +- 3.22 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=256MB
LLR   | 2.98 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 22376 W: 5740 L: 5481 D: 11155
```

Bench: 9569072