### PR TITLE
Don't keep bestmove from irrelevant positions

### DIFF
--- a/engine/src/body/tt.rs
+++ b/engine/src/body/tt.rs
@@ -180,13 +180,15 @@ impl TT {
 
         // Only replace entries of similar or higher quality
         if entry.quality() >= target.quality() {
+            let positions_differ = target.key != entry.key;
+
             target.key = entry.key;
             target.score = entry.score;
             target.depth = entry.depth;
             target.age_flag = entry.age_flag;
 
             // Do not overwrite the move if there was no new best move
-            if mv.is_some() {
+            if mv.is_some() || positions_differ {
                 target.mv = entry.mv;
             }
         }


### PR DESCRIPTION
```
ELO   | 2.39 +- 3.73 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.98 (-2.94, 2.94) [-3.00, 2.00]
GAMES | N: 17624 W: 4731 L: 4610 D: 8283
https://chess.swehosting.se/test/2708/
```

Bench: 13234 ms 9444271 nodes 726482 nps